### PR TITLE
support 0.7 and 0.8 both as latest version for autoUpgrade

### DIFF
--- a/Products/CNXMLDocument/CNXMLFile.py
+++ b/Products/CNXMLDocument/CNXMLFile.py
@@ -72,7 +72,7 @@ def autoUpgrade(source, **params):
     """
     version = Recognizer(source).getVersion() # if wrong, we could end up doing this on every save
     stylesheets = []
-    if version == '0.7':
+    if version in ('0.7', '0.8'):
         pass # Do nothing. 0.7 is the latest
     elif version == '0.6':
         stylesheets.append(UPGRADE_06_TO_07_XSL)


### PR DESCRIPTION
We added XML schema to support both 0.7 and 0.8, but failed to notice that the autoUgrade (called when building the complete zip)  chokes on 0.8 versioned content